### PR TITLE
fix: :bug: updated git fetch to better detect the ancestry of the branches and correctly determine the validity of the branch merge request

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,14 @@ echo "FEATURE_PATTERN=$FEATURE_PATTERN"
 # mark repo directory as safe to prevent 'dubious ownership' detected in the repository
 git config --global --add safe.directory /github/workspace
 
+# change to workspace directory
+cd /github/workspace || exit 1
+
+# Fetch all remote branches with full history needed for merge-base comparison
+# GitHub Actions provides a shallow clone, so we need to unshallow and fetch all refs
+git fetch --unshallow origin '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || \
+    git fetch origin '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || true
+
 # hotfixes can be merged anywhere
 echo "-> checking if hotfix"
 if isHotfix; then

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# Test script for entrypoint.sh
+# Simulates the GitHub Actions environment locally
+#
+# Usage:
+#   ./test-entrypoint.sh <repo_name> <source_branch> [target_branch=testing]
+#
+# Examples:
+#   ./test-entrypoint.sh aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver
+#   ./test-entrypoint.sh aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver testing
+#   ./test-entrypoint.sh aws.appsync.compass-select hotfix/eng-1158-inconsistent-response production
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+REPO_NAME="${1}"
+SOURCE_BRANCH="${2}"
+TARGET_BRANCH="${3:-testing}"
+
+# Validate required arguments
+if [ -z "${REPO_NAME}" ] || [ -z "${SOURCE_BRANCH}" ]; then
+    echo -e "${RED}Error: Missing required arguments${NC}"
+    echo ""
+    echo "Usage: $0 <repo_name> <source_branch> [target_branch]"
+    echo ""
+    echo "Arguments:"
+    echo "  repo_name       Repository name (without bricklanetech/ prefix)"
+    echo "  source_branch   The branch being merged (e.g., feature/my-feature)"
+    echo "  target_branch   The branch being merged into (default: testing)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver"
+    echo "  $0 aws.appsync.compass-select testing production"
+    exit 1
+fi
+
+# Configuration
+GITHUB_ORG="bricklanetech"
+REPO_URL="https://github.com/${GITHUB_ORG}/${REPO_NAME}.git"
+TEST_DIR="/tmp/control-merge-test-${REPO_NAME}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT_SCRIPT="${SCRIPT_DIR}/entrypoint.sh"
+
+echo -e "${YELLOW}=== Control Merge Action Test ===${NC}"
+echo ""
+echo "Repository:    ${GITHUB_ORG}/${REPO_NAME}"
+echo "Source branch: ${SOURCE_BRANCH}"
+echo "Target branch: ${TARGET_BRANCH}"
+echo "Test dir:      ${TEST_DIR}"
+echo ""
+
+# Check entrypoint script exists
+if [ ! -f "${ENTRYPOINT_SCRIPT}" ]; then
+    echo -e "${RED}Error: entrypoint.sh not found at ${ENTRYPOINT_SCRIPT}${NC}"
+    exit 1
+fi
+
+# Clean up previous test directory
+echo -e "${YELLOW}-> Preparing test environment${NC}"
+rm -rf "${TEST_DIR}"
+
+# Clone repository with shallow clone (simulates GitHub Actions checkout)
+echo -e "${YELLOW}-> Cloning repository (shallow clone to simulate GitHub Actions)${NC}"
+if ! git clone --depth=1 "${REPO_URL}" "${TEST_DIR}" 2>&1; then
+    echo -e "${RED}Error: Failed to clone repository${NC}"
+    exit 1
+fi
+
+# Set up GitHub Actions environment variables
+echo -e "${YELLOW}-> Setting up environment variables${NC}"
+export GITHUB_HEAD_REF="${SOURCE_BRANCH}"
+export GITHUB_BASE_REF="${TARGET_BRANCH}"
+export INPUT_WORKFLOW="testing production"
+export INPUT_HOTFIX_PATTERN="hotfix/*"
+export INPUT_FEATURE_PATTERN="feature/*"
+export GITHUB_OUTPUT="/dev/stdout"
+
+echo "  GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
+echo "  GITHUB_BASE_REF=${GITHUB_BASE_REF}"
+echo "  INPUT_WORKFLOW=${INPUT_WORKFLOW}"
+echo "  INPUT_HOTFIX_PATTERN=${INPUT_HOTFIX_PATTERN}"
+echo "  INPUT_FEATURE_PATTERN=${INPUT_FEATURE_PATTERN}"
+echo ""
+
+# Change to test directory
+cd "${TEST_DIR}"
+
+# Run the entrypoint script (replacing /github/workspace with test directory)
+echo -e "${YELLOW}-> Running entrypoint.sh${NC}"
+echo "----------------------------------------"
+
+# Create a modified version of the script for local testing
+TEMP_SCRIPT=$(mktemp)
+sed "s|/github/workspace|${TEST_DIR}|g" "${ENTRYPOINT_SCRIPT}" > "${TEMP_SCRIPT}"
+chmod +x "${TEMP_SCRIPT}"
+
+# Run the script and capture exit code
+set +e
+bash "${TEMP_SCRIPT}"
+EXIT_CODE=$?
+set -e
+
+echo "----------------------------------------"
+echo ""
+
+# Clean up temp script
+rm -f "${TEMP_SCRIPT}"
+
+# Report result
+if [ ${EXIT_CODE} -eq 0 ]; then
+    echo -e "${GREEN}✔ Test PASSED (exit code: ${EXIT_CODE})${NC}"
+else
+    echo -e "${RED}✘ Test FAILED (exit code: ${EXIT_CODE})${NC}"
+fi
+
+# Optional: Clean up test directory
+# rm -rf "${TEST_DIR}"
+
+exit ${EXIT_CODE}

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -3,13 +3,25 @@
 # Test script for entrypoint.sh
 # Simulates the GitHub Actions environment locally
 #
+# This script automatically detects the workflow configuration from the repository's
+# GitHub Actions workflow files (looks for 'workflow:' in .github/workflows/*.yml)
+#
 # Usage:
-#   ./test-entrypoint.sh <repo_name> <source_branch> [target_branch=testing]
+#   ./test-entrypoint.sh <repo_name> <source_branch> [target_branch] [--workflow "branch1 branch2 ..."]
+#
+# Arguments:
+#   repo_name       Repository name (without bricklanetech/ prefix)
+#   source_branch   The branch being merged (e.g., feature/my-feature)
+#   target_branch   The branch being merged into (default: first branch in detected workflow, or "testing")
+#   --workflow      Override: space-separated list of workflow branches (auto-detected from repo if not provided)
 #
 # Examples:
+#   # Auto-detect workflow from repo
 #   ./test-entrypoint.sh aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver
 #   ./test-entrypoint.sh aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver testing
-#   ./test-entrypoint.sh aws.appsync.compass-select hotfix/eng-1158-inconsistent-response production
+#
+#   # Override with custom workflow
+#   ./test-entrypoint.sh aws.appsync.compass-select feature/my-feature develop --workflow "develop staging main"
 #
 
 set -e
@@ -18,27 +30,67 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Fallback workflow if not detected from repo
+FALLBACK_WORKFLOW="testing production"
+
 # Parse arguments
-REPO_NAME="${1}"
-SOURCE_BRANCH="${2}"
-TARGET_BRANCH="${3:-testing}"
+REPO_NAME=""
+SOURCE_BRANCH=""
+TARGET_BRANCH=""
+WORKFLOW=""
+
+# Parse positional and flag arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workflow)
+            WORKFLOW="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 <repo_name> <source_branch> [target_branch] [--workflow \"branch1 branch2 ...]\]"
+            echo ""
+            echo "Run '$0' without arguments for detailed help."
+            exit 0
+            ;;
+        *)
+            # Positional arguments
+            if [ -z "${REPO_NAME}" ]; then
+                REPO_NAME="$1"
+            elif [ -z "${SOURCE_BRANCH}" ]; then
+                SOURCE_BRANCH="$1"
+            elif [ -z "${TARGET_BRANCH}" ]; then
+                TARGET_BRANCH="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Apply defaults (target branch default applied after workflow detection)
+WORKFLOW_OVERRIDE="${WORKFLOW}"
 
 # Validate required arguments
 if [ -z "${REPO_NAME}" ] || [ -z "${SOURCE_BRANCH}" ]; then
-    echo -e "${RED}Error: Missing required arguments${NC}"
+    echo -e "${RED}❌ Error: Missing required arguments${NC}"
     echo ""
-    echo "Usage: $0 <repo_name> <source_branch> [target_branch]"
+    echo "Usage: $0 <repo_name> <source_branch> [target_branch] [--workflow \"branch1 branch2 ...\"]"
     echo ""
     echo "Arguments:"
     echo "  repo_name       Repository name (without bricklanetech/ prefix)"
     echo "  source_branch   The branch being merged (e.g., feature/my-feature)"
-    echo "  target_branch   The branch being merged into (default: testing)"
+    echo "  target_branch   The branch being merged into (default: auto-detected from repo)"
+    echo "  --workflow      Override workflow (auto-detected from repo's .github/workflows/*.yml)"
     echo ""
     echo "Examples:"
+    echo "  # Auto-detect workflow from repo"
     echo "  $0 aws.appsync.compass-select feature/eng-976-create-adjust-js-resolver"
     echo "  $0 aws.appsync.compass-select testing production"
+    echo ""
+    echo "  # Override workflow"
+    echo "  $0 aws.appsync.compass-select feature/my-feature develop --workflow \"develop staging main\""
     exit 1
 fi
 
@@ -49,36 +101,141 @@ TEST_DIR="/tmp/control-merge-test-${REPO_NAME}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENTRYPOINT_SCRIPT="${SCRIPT_DIR}/entrypoint.sh"
 
-echo -e "${YELLOW}=== Control Merge Action Test ===${NC}"
-echo ""
-echo "Repository:    ${GITHUB_ORG}/${REPO_NAME}"
-echo "Source branch: ${SOURCE_BRANCH}"
-echo "Target branch: ${TARGET_BRANCH}"
-echo "Test dir:      ${TEST_DIR}"
-echo ""
-
 # Check entrypoint script exists
 if [ ! -f "${ENTRYPOINT_SCRIPT}" ]; then
-    echo -e "${RED}Error: entrypoint.sh not found at ${ENTRYPOINT_SCRIPT}${NC}"
+    echo -e "${RED}❌ Error: entrypoint.sh not found at ${ENTRYPOINT_SCRIPT}${NC}"
     exit 1
 fi
 
 # Clean up previous test directory
-echo -e "${YELLOW}-> Preparing test environment${NC}"
+echo -e "${YELLOW}🧹 Preparing test environment${NC}"
 rm -rf "${TEST_DIR}"
 
 # Clone repository with shallow clone (simulates GitHub Actions checkout)
-echo -e "${YELLOW}-> Cloning repository (shallow clone to simulate GitHub Actions)${NC}"
+echo -e "${YELLOW}📥 Cloning repository (shallow clone to simulate GitHub Actions)${NC}"
 if ! git clone --depth=1 "${REPO_URL}" "${TEST_DIR}" 2>&1; then
-    echo -e "${RED}Error: Failed to clone repository${NC}"
+    echo -e "${RED}❌ Error: Failed to clone repository${NC}"
+    echo -e "${RED}   Check that '${REPO_NAME}' is correct and you have access to ${REPO_URL}${NC}"
     exit 1
 fi
 
+# Change to test directory
+cd "${TEST_DIR}"
+
+# Auto-detect workflow from repo's GitHub Actions workflow files
+if [ -z "${WORKFLOW_OVERRIDE}" ]; then
+    echo -e "${YELLOW}🔎 Auto-detecting workflow from .github/workflows/*.yml${NC}"
+
+    # Look for 'workflow:' in workflow files and extract the value
+    DETECTED_WORKFLOW=""
+    if [ -d ".github/workflows" ]; then
+        # Search for workflow: configuration in yml files
+        DETECTED_WORKFLOW=$(grep -rh "workflow:" .github/workflows/*.yml 2>/dev/null | \
+            head -1 | \
+            sed 's/.*workflow:[[:space:]]*//' | \
+            tr -d '\r' | \
+            xargs)
+    fi
+
+    if [ -n "${DETECTED_WORKFLOW}" ]; then
+        WORKFLOW="${DETECTED_WORKFLOW}"
+        echo -e "${GREEN}   ✅ Detected workflow: ${WORKFLOW}${NC}"
+    else
+        WORKFLOW="${FALLBACK_WORKFLOW}"
+        echo -e "${YELLOW}   ⚠️  Could not detect workflow, using fallback: ${WORKFLOW}${NC}"
+    fi
+else
+    WORKFLOW="${WORKFLOW_OVERRIDE}"
+    echo -e "${BLUE}   ℹ️  Using provided workflow: ${WORKFLOW}${NC}"
+fi
+
+# Apply target branch default (first branch in workflow)
+WORKFLOW_ARRAY=(${WORKFLOW})
+if [ -z "${TARGET_BRANCH}" ]; then
+    TARGET_BRANCH="${WORKFLOW_ARRAY[0]}"
+    echo -e "${BLUE}   ℹ️  Target branch defaulting to first workflow branch: ${TARGET_BRANCH}${NC}"
+fi
+
+# Validate workflow has at least 2 branches
+if [ ${#WORKFLOW_ARRAY[@]} -lt 2 ]; then
+    echo -e "${RED}❌ Error: Workflow must have at least 2 branches${NC}"
+    echo -e "${RED}   Got: '${WORKFLOW}'${NC}"
+    echo ""
+    echo "Example: --workflow \"testing production\" or --workflow \"develop staging main\""
+    exit 1
+fi
+
+# Validate target branch is in the workflow
+TARGET_IN_WORKFLOW=false
+for branch in "${WORKFLOW_ARRAY[@]}"; do
+    if [ "${branch}" = "${TARGET_BRANCH}" ]; then
+        TARGET_IN_WORKFLOW=true
+        break
+    fi
+done
+
+if [ "${TARGET_IN_WORKFLOW}" = false ]; then
+    echo -e "${RED}❌ Error: Target branch '${TARGET_BRANCH}' is not in the workflow${NC}"
+    echo -e "${RED}   Workflow: ${WORKFLOW}${NC}"
+    echo ""
+    echo "Either:"
+    echo "  1. Change target_branch to one of: ${WORKFLOW}"
+    echo "  2. Use --workflow to specify a workflow that includes '${TARGET_BRANCH}'"
+    exit 1
+fi
+
+echo ""
+echo -e "${YELLOW}🧪 === Control Merge Action Test ===${NC}"
+echo ""
+echo "📦 Repository:    ${GITHUB_ORG}/${REPO_NAME}"
+echo "🌿 Source branch: ${SOURCE_BRANCH}"
+echo "🎯 Target branch: ${TARGET_BRANCH}"
+echo "🔀 Workflow:      ${WORKFLOW}"
+echo "📁 Test dir:      ${TEST_DIR}"
+echo ""
+
+# Verify SOURCE_BRANCH exists
+echo -e "${YELLOW}🔍 Verifying source branch exists: ${SOURCE_BRANCH}${NC}"
+if ! git rev-parse --verify "origin/${SOURCE_BRANCH}" >/dev/null 2>&1; then
+    echo -e "${YELLOW}   ⏳ Branch not in shallow clone, fetching...${NC}"
+    if ! git fetch origin "${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" --depth=1 2>&1; then
+        echo -e "${RED}❌ Error: Source branch '${SOURCE_BRANCH}' does not exist in repository${NC}"
+        echo -e "${RED}   Possible causes:${NC}"
+        echo -e "${RED}   • Typo in branch name${NC}"
+        echo -e "${RED}   • Branch was deleted or not yet pushed${NC}"
+        echo -e "${RED}   • Wrong repository (currently using: ${REPO_URL})${NC}"
+        echo ""
+        echo -e "${YELLOW}   📋 Available branches:${NC}"
+        git ls-remote --heads origin | head -20 | sed 's/.*refs\/heads\//    /'
+        exit 1
+    fi
+fi
+echo -e "${GREEN}   ✅ origin/${SOURCE_BRANCH} exists${NC}"
+
+# Verify TARGET_BRANCH exists
+echo -e "${YELLOW}🔍 Verifying target branch exists: ${TARGET_BRANCH}${NC}"
+if ! git rev-parse --verify "origin/${TARGET_BRANCH}" >/dev/null 2>&1; then
+    echo -e "${YELLOW}   ⏳ Branch not in shallow clone, fetching...${NC}"
+    if ! git fetch origin "${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --depth=1 2>&1; then
+        echo -e "${RED}❌ Error: Target branch '${TARGET_BRANCH}' does not exist in repository${NC}"
+        echo -e "${RED}   Possible causes:${NC}"
+        echo -e "${RED}   • Typo in branch name${NC}"
+        echo -e "${RED}   • Branch was deleted or not yet created${NC}"
+        echo -e "${RED}   • Wrong repository (currently using: ${REPO_URL})${NC}"
+        echo ""
+        echo -e "${YELLOW}   📋 Available branches:${NC}"
+        git ls-remote --heads origin | head -20 | sed 's/.*refs\/heads\//    /'
+        exit 1
+    fi
+fi
+echo -e "${GREEN}   ✅ origin/${TARGET_BRANCH} exists${NC}"
+echo ""
+
 # Set up GitHub Actions environment variables
-echo -e "${YELLOW}-> Setting up environment variables${NC}"
+echo -e "${YELLOW}⚙️  Setting up environment variables${NC}"
 export GITHUB_HEAD_REF="${SOURCE_BRANCH}"
 export GITHUB_BASE_REF="${TARGET_BRANCH}"
-export INPUT_WORKFLOW="testing production"
+export INPUT_WORKFLOW="${WORKFLOW}"
 export INPUT_HOTFIX_PATTERN="hotfix/*"
 export INPUT_FEATURE_PATTERN="feature/*"
 export GITHUB_OUTPUT="/dev/stdout"
@@ -90,12 +247,9 @@ echo "  INPUT_HOTFIX_PATTERN=${INPUT_HOTFIX_PATTERN}"
 echo "  INPUT_FEATURE_PATTERN=${INPUT_FEATURE_PATTERN}"
 echo ""
 
-# Change to test directory
-cd "${TEST_DIR}"
-
 # Run the entrypoint script (replacing /github/workspace with test directory)
-echo -e "${YELLOW}-> Running entrypoint.sh${NC}"
-echo "----------------------------------------"
+echo -e "${YELLOW}🚀 Running entrypoint.sh${NC}"
+echo "────────────────────────────────────────"
 
 # Create a modified version of the script for local testing
 TEMP_SCRIPT=$(mktemp)
@@ -108,7 +262,7 @@ bash "${TEMP_SCRIPT}"
 EXIT_CODE=$?
 set -e
 
-echo "----------------------------------------"
+echo "────────────────────────────────────────"
 echo ""
 
 # Clean up temp script
@@ -116,9 +270,9 @@ rm -f "${TEMP_SCRIPT}"
 
 # Report result
 if [ ${EXIT_CODE} -eq 0 ]; then
-    echo -e "${GREEN}✔ Test PASSED (exit code: ${EXIT_CODE})${NC}"
+    echo -e "${GREEN}🎉 Test PASSED (exit code: ${EXIT_CODE})${NC}"
 else
-    echo -e "${RED}✘ Test FAILED (exit code: ${EXIT_CODE})${NC}"
+    echo -e "${RED}💥 Test FAILED (exit code: ${EXIT_CODE})${NC}"
 fi
 
 # Optional: Clean up test directory


### PR DESCRIPTION
Update the way Git retrieves information (specifically ancestry) for a branch.

Fix for the error:

```
Run bricklanetech/action.control-merge@v1
/usr/bin/docker run --name f7c3612010521d0bc04c488155a96c1d946141_f1d795 --label f7c361 --workdir /github/workspace --rm -e "GITHUB_TOKEN" -e "INPUT_WORKFLOW" -e "INPUT_FEATURE_PATTERN" -e "INPUT_HOTFIX_PATTERN" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITH
-> checking if hotfix
-> checking if merge is allowed in the workflow rules
--> source is feature branch and target either another feature or start of workflow
-> checking if branch is blocked
fatal: ambiguous argument 'origin/testing': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'origin/production': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: Not a valid object name origin/testing
--> Branch is blocked
fatal: ambiguous argument 'origin/testing': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'origin/testing': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
✘ Branch testing is awaiting merge into production, please check with 
'git <command> [<revision>...] -- [<file>...]'
```