### PR TITLE
feat: add chore_pattern input, treated like feature branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ A Github action to check whether a merge/PR is permitted to happen between branc
     workflow: a b c # default: main
     feature_pattern: feature/* # default: feature/*
     hotfix_pattern: hotfix/* # default: hotfix/*
+    chore_pattern: chore/* # default: chore/*
 ```
 
 ## Using the `with` statement
 
-The with statement is used for this action to provide a pattern to be used for feature and hotfix branches (the concepts of both branch types are based on the GitFlow workflow), along with a list of branches to be used as a control workflow to allow merges from one branch to another (for multi-stage release processes etc).
+The with statement is used for this action to provide a pattern to be used for feature and hotfix branches (the concepts of both branch types are based on the GitFlow workflow), along with a list of branches to be used as a control workflow to allow merges from one branch to another (for multi-stage release processes etc). A `chore` pattern is also supported; chore branches are treated identically to feature branches.
 
 Wildcards as allowed by `grep` are permitted in the source branch values, such as `hotfix/*`.
 
@@ -25,7 +26,7 @@ Wildcards as allowed by `grep` are permitted in the source branch values, such a
 
 The general rules for merging between different branches is that:
 
-- a `feature` may **ONLY** merge into other features or `workflow[0]`
+- a `feature` (or `chore`) may **ONLY** merge into other features/chores or `workflow[0]`
 - `workflow[n]` may **ONLY** merge into `workflow[n+1]`
 - a `hotfix` may merge into **ANY** branch
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: the grep pattern to use for the format of feature branches (development branches that are yet to be added to workflow)
     required: false
     default: feature/*
+  chore_pattern:
+    description: the grep pattern to use for the format of chore branches (maintenance branches, treated the same as feature branches)
+    required: false
+    default: chore/*
 outputs:
   response:
     description: message provided for either success or failure, depending on reason for failure

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,12 @@ isHotfix() {
     return $(echo "${SOURCE_BRANCH}" | grep -qe "${HOTFIX_PATTERN}")
 }
 
-# checks if source branch is a feature and returns success (or failure if not)
+# checks if source branch is a feature (or chore) and returns success (or failure if not)
+# chore branches are treated identically to feature branches
 isFeature() {
     TARGET=${1:-$SOURCE_BRANCH}
-    return $(echo "${TARGET}" | grep -qe "${FEATURE_PATTERN}")
+    echo "${TARGET}" | grep -qe "${FEATURE_PATTERN}" && return 0
+    echo "${TARGET}" | grep -qe "${CHORE_PATTERN}"
 }
 
 # checks if merge is permitted via the defined workflow array
@@ -96,6 +98,7 @@ TARGET_BRANCH="${GITHUB_BASE_REF}"
 WORKFLOW=(${INPUT_WORKFLOW})
 HOTFIX_PATTERN="${INPUT_HOTFIX_PATTERN}"
 FEATURE_PATTERN="${INPUT_FEATURE_PATTERN}"
+CHORE_PATTERN="${INPUT_CHORE_PATTERN}"
 
 POSITION_SOURCE=$(indexOf "${SOURCE_BRANCH}" "${WORKFLOW[@]}")
 POSITION_TARGET=$(indexOf "${TARGET_BRANCH}" "${WORKFLOW[@]}")
@@ -107,6 +110,7 @@ echo "TARGET_BRANCH=$TARGET_BRANCH"
 echo "WORKFLOW=$WORKFLOW"
 echo "HOTFIX_PATTERN=$HOTFIX_PATTERN"
 echo "FEATURE_PATTERN=$FEATURE_PATTERN"
+echo "CHORE_PATTERN=$CHORE_PATTERN"
 
 # mark repo directory as safe to prevent 'dubious ownership' detected in the repository
 git config --global --add safe.directory /github/workspace

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -242,6 +242,7 @@ export GITHUB_BASE_REF="${TARGET_BRANCH}"
 export INPUT_WORKFLOW="${WORKFLOW}"
 export INPUT_HOTFIX_PATTERN="hotfix/*"
 export INPUT_FEATURE_PATTERN="feature/*"
+export INPUT_CHORE_PATTERN="chore/*"
 export GITHUB_OUTPUT="/dev/stdout"
 
 echo "  GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
@@ -249,6 +250,7 @@ echo "  GITHUB_BASE_REF=${GITHUB_BASE_REF}"
 echo "  INPUT_WORKFLOW=${INPUT_WORKFLOW}"
 echo "  INPUT_HOTFIX_PATTERN=${INPUT_HOTFIX_PATTERN}"
 echo "  INPUT_FEATURE_PATTERN=${INPUT_FEATURE_PATTERN}"
+echo "  INPUT_CHORE_PATTERN=${INPUT_CHORE_PATTERN}"
 echo ""
 
 # Run the entrypoint script (replacing /github/workspace with test directory)


### PR DESCRIPTION
## What

Adds a `chore_pattern` input (default `chore/*`) and treats chore branches identically to feature branches.

`chore/` is a first-class development-branch prefix in the team git workflow (`chore/{ticket-id}-…`), alongside `feature/` and `hotfix/`. Until now the action only recognised `feature_pattern` and `hotfix_pattern`, so a consumer wanting chore branches to be allowed into the start of a workflow had to overload `feature_pattern` (e.g. `feature/*\|chore/*`) — passing a `chore_pattern` input silently did nothing.

## Changes

- **`action.yml`** — new optional `chore_pattern` input, default `chore/*`.
- **`entrypoint.sh`** — read `INPUT_CHORE_PATTERN`; extend `isFeature()` to also match the chore pattern, so chore branches follow the exact same merge rules as feature branches (may merge into `workflow[0]` or into another feature/chore branch, nowhere else). Added a debug echo for the new pattern.
- **`test-entrypoint.sh`** — export `INPUT_CHORE_PATTERN` in the local harness so it mirrors the action environment.
- **`README.md`** — document the input and the merging rule.

## Merge-rule semantics

A `chore` branch is treated exactly like a `feature` branch — it is **not** given hotfix-style "merge anywhere" rights.

## Backwards compatibility

Additive and backwards compatible. The `chore_pattern` default is `chore/*`; the default cannot be empty because `grep -qe ""` matches every branch. Consumers that upgrade will therefore start allowing `chore/` branches by default — this matches the git-workflow standard, but is an intentional estate-wide behaviour change to be aware of.

## Testing

Verified `isFeature`/`isHotfix` classification in an Alpine/BusyBox container (the action's runtime):

| branch | isFeature | isHotfix |
|---|---|---|
| `feature/foo` | ✅ | no |
| `chore/foo` | ✅ | no |
| `hotfix/foo` | no | ✅ |
| `test` / `production` | no | no |

`bash -n entrypoint.sh` passes.

## Follow-up

Once released (publish.yml auto-cuts a new minor and moves the `v2` / `latest` aliases), consumers pinned to `@v2.1` — e.g. `compass` — should bump to `@v2` to pick this up.
